### PR TITLE
Updated the memory allocation to mbedtls_platform_calloc to eliminate…

### DIFF
--- a/stm32/Projects/Common/net/mbedtls_transport.c
+++ b/stm32/Projects/Common/net/mbedtls_transport.c
@@ -463,7 +463,7 @@ NetworkContext_t * mbedtls_transport_allocate( void )
 {
     TLSContext_t * pxTLSCtx = NULL;
 
-    pxTLSCtx = ( TLSContext_t * ) pvPortMalloc( sizeof( TLSContext_t ) );
+    pxTLSCtx = ( TLSContext_t * ) mbedtls_platform_calloc( 1, sizeof( TLSContext_t ) );
 
     if( pxTLSCtx == NULL )
     {
@@ -1473,7 +1473,7 @@ int32_t mbedtls_transport_setrecvcallback( NetworkContext_t * pxNetworkContext,
 
     if( pxNotifyThreadCtx == NULL )
     {
-        pxNotifyThreadCtx = pvPortMalloc( sizeof( NotifyThreadCtx_t ) );
+        pxNotifyThreadCtx = mbedtls_platform_calloc(1, sizeof( NotifyThreadCtx_t ) );
 
         if( pxNotifyThreadCtx == NULL )
         {


### PR DESCRIPTION
*Issue #, if available:*
When attempting to create a task that uses the mbedtls_transport interface without registering the mbedtls_transport_setrecvcallback() function, the mbedtls_transport_connect() function attempts to create a notify task. However, it bypasses pointer validation, leading to a HardFault due to dereferencing garbage memory in the following code snippet:
```
if( ( xStatus == TLS_TRANSPORT_SUCCESS ) &&
            pxTLSCtx->pxNotifyThreadCtx ) 
```
*Description of changes:*
Replaced pvportMalloc() with mbedtls_platform_calloc() to ensure that the allocated memory is zero-initialized. This prevents the potential dereferencing of uninitialized or invalid memory and resolves the HardFault issue.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
